### PR TITLE
Add VentMode coordinates for 4-screen vital reader

### DIFF
--- a/bed_coords_4.py
+++ b/bed_coords_4.py
@@ -21,6 +21,7 @@ BASE_COORDS = {
     "sRR":   ( 318, 508,  52, 32),
     "TV":    ( 397, 506,  50, 33),
     "Ti":    ( 630, 506,  61, 32),
+    "VentMode": (109, 35, 143, 27),
 }
 
 BED_WIDTH = 1920
@@ -55,6 +56,7 @@ def _build_bed(dx, dy):
             "RRact": b["sRR"],
             "VTset": b["TV"],
             "Ti": b["Ti"],
+            "VentMode": b["VentMode"],
         },
     }
 

--- a/vital_reader.py
+++ b/vital_reader.py
@@ -488,7 +488,7 @@ def ocr_vitals_from_image(image_path):
 ALL_COLUMNS = [
     "SBP", "DBP", "MAP", "HR", "SpO2", "BSR1", "BSR2", "Tskin", "Trect", "etCO2",
     "RR", "Ppeak", "Pmean", "PEEPact", "RRact", "I_E", "FiO2", "VTe", "VTi",
-    "PEEPset", "VTset", "CVP", "pH", "PaCO2", "pO2", "Hct", "K", "Na", "Cl",
+    "PEEPset", "VTset", "VentMode", "CVP", "pH", "PaCO2", "pO2", "Hct", "K", "Na", "Cl",
     "Ca", "Glu", "Lac", "tBil", "HCO3", "BE", "Alb"
 ]
 


### PR DESCRIPTION
## Summary
- capture ventilator mode in 4-screen layout by adding VentMode coords
- store VentMode result when saving vitals

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf7b020e98832b91a1ad01b1e044db