### PR TITLE
Host-based defaults for bed selection and capture

### DIFF
--- a/auto_capture.py
+++ b/auto_capture.py
@@ -7,6 +7,7 @@ import argparse
 from pathlib import Path
 import json
 from typing import List, Optional
+import socket
 
 # =========================
 # 設定ロード
@@ -44,6 +45,13 @@ def resolve_path(
 
 DEFAULT_IMAGE_BASE_CANDIDATES = [r"Z:\\image"]
 
+# Host-specific default monitor and capture region
+# (region uses left/top/width/height; full HD as placeholder)
+HOST_DEFAULTS = {
+    "ws-PC1": {"monitor": 1, "region": {"left": 0, "top": 0, "width": 1920, "height": 1080}},
+    "Super-WS": {"monitor": 1, "region": {"left": 0, "top": 0, "width": 1920, "height": 1080}},
+}
+
 parser = argparse.ArgumentParser(description="Capture screenshots from a specific monitor.")
 parser.add_argument("--config", help="Path to config.json")
 parser.add_argument("--image-folder", help="Base directory to save images")
@@ -69,20 +77,48 @@ base_dir = resolve_path(
 )
 base_dir.mkdir(parents=True, exist_ok=True)
 
+host_defaults = HOST_DEFAULTS.get(socket.gethostname(), {})
+
+monitor_number = args.monitor
+left, top, width, height = args.left, args.top, args.width, args.height
+
+if monitor_number is None:
+    env_mon = os.getenv("CAPTURE_MONITOR")
+    if env_mon is not None:
+        monitor_number = int(env_mon)
+    elif "monitor" in host_defaults:
+        monitor_number = host_defaults["monitor"]
+
+if None in (left, top, width, height):
+    env_vals = [
+        os.getenv("CAPTURE_LEFT"),
+        os.getenv("CAPTURE_TOP"),
+        os.getenv("CAPTURE_WIDTH"),
+        os.getenv("CAPTURE_HEIGHT"),
+    ]
+    if all(env_vals):
+        left, top, width, height = map(int, env_vals)
+    elif "region" in host_defaults:
+        region = host_defaults["region"]
+        left = region["left"]
+        top = region["top"]
+        width = region["width"]
+        height = region["height"]
+
 try:
     with mss() as sct:
-        if None not in (args.left, args.top, args.width, args.height):
+        if None not in (left, top, width, height):
             monitor = {
-                "left": args.left,
-                "top": args.top,
-                "width": args.width,
-                "height": args.height,
+                "left": left,
+                "top": top,
+                "width": width,
+                "height": height,
             }
             print(
                 f"📸 座標指定でスクリーンショット開始（{args.interval}秒おき）: {monitor}"
             )
         else:
-            if args.monitor is None:
+            if monitor_number is None:
                 print("利用可能なモニター:")
                 for i, mon in enumerate(sct.monitors[1:], start=1):
                     print(
@@ -98,8 +134,6 @@ try:
                         print("⚠️ 無効なモニター番号です。")
                     except ValueError:
                         print("⚠️ 数値を入力してください。")
-            else:
-                monitor_number = args.monitor
             monitor = sct.monitors[monitor_number]
             print(
                 f"📸 モニター{monitor_number}のスクリーンショット開始（{args.interval}秒おき）"

--- a/vital_reader.py
+++ b/vital_reader.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from pathlib import Path
 import argparse
 import json
+import socket
 from typing import Optional
 try:  # pragma: no cover - optional dependency
     import numpy as np  # type: ignore
@@ -226,6 +227,10 @@ def parse_args():
     parser.add_argument("--image-folder", help="Folder containing monitor images (親Z:\\imageでもOK)")
     parser.add_argument("--vitals-base", help="Folder to store CSVs (親フォルダ)。未指定なら自動推定")
     parser.add_argument("--config", help="Path to config JSON file")
+    parser.add_argument(
+        "--beds",
+        help="Comma-separated bed numbers to allow. Overrides host-based default.",
+    )
     return parser.parse_args()
 
 # =========================
@@ -305,8 +310,12 @@ def create_empty_vitals_csv(path):
         df.to_csv(path, index=False, encoding="utf-8-sig")
         print(f"[INFO] 空のバイタルCSVを作成: {path}")
 
-def select_display_and_bed(vitals_base_dir: Path):
-    """画面分割(4 or 8)とベッド番号を聞いてCSVパスとともに返す"""
+def select_display_and_bed(vitals_base_dir: Path, beds_override: Optional[list[str]] = None):
+    """画面分割(4 or 8)とベッド番号を聞いてCSVパスとともに返す
+
+    ホスト名に応じてベッド候補を切り替える。`beds_override` が指定された場合は
+    それを優先する。
+    """
     import tkinter as tk
     from tkinter import simpledialog, messagebox
 
@@ -324,7 +333,16 @@ def select_display_and_bed(vitals_base_dir: Path):
             break
         messagebox.showerror("エラー", "4または8を入力してください。", parent=root)
 
-    valid_beds = ["2", "3", "4", "5"]
+    host = socket.gethostname()
+    if beds_override is not None:
+        valid_beds = beds_override
+    elif host == "ws-PC1":
+        valid_beds = ["2", "3"]
+    elif host == "Super-WS":
+        valid_beds = ["4", "5"]
+    else:
+        valid_beds = ["2", "3", "4", "5"]
+
     while True:
         bed_choice = simpledialog.askstring(
             "ベッド選択",
@@ -742,8 +760,18 @@ if __name__ == "__main__":
 
     init_resources(cvp_model_path, spont_breath_model_path, spont_breath_meta_path)
 
+    beds_override = None
+    if args.beds:
+        beds_override = [b.strip() for b in args.beds.split(",") if b.strip()]
+    else:
+        env_beds = os.getenv("VALID_BEDS")
+        if env_beds:
+            beds_override = [b.strip() for b in env_beds.split(",") if b.strip()]
+
     # ==== 表示モード & ベッド選択 ====
-    display_mode, VITALS_PATH, bed_num = select_display_and_bed(vitals_base_dir)
+    display_mode, VITALS_PATH, bed_num = select_display_and_bed(
+        vitals_base_dir, beds_override
+    )
     print(f"選択された画面分割: {display_mode}")
     print(f"選択されたベッド番号: {bed_num}")
     print(f"保存先CSV: {VITALS_PATH}")


### PR DESCRIPTION
## Summary
- choose valid beds based on hostname with optional `--beds`/`VALID_BEDS` overrides
- auto-select monitor and capture region from hostname with optional env vars

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c600b16c58832b9358228482311bbc