### PR TITLE
Improve BP parsing fallbacks

### DIFF
--- a/tests/test_vital_reader_bp.py
+++ b/tests/test_vital_reader_bp.py
@@ -25,11 +25,29 @@ def test_parse_bp_text_fallback_four_digits():
     assert map_val == "89"
 
 
+def test_parse_bp_text_handles_decimal_tokens_without_separators():
+    raw = "11.0 97.0 57.0"
+    text, sbp, dbp, map_val = vital_reader.parse_bp_text(raw)
+    assert text == "110970570"
+    assert sbp == "110"
+    assert dbp == "97"
+    assert map_val == "57"
+
+
+def test_parse_bp_text_handles_missing_slash():
+    raw = "11097(57"
+    text, sbp, dbp, map_val = vital_reader.parse_bp_text(raw)
+    assert text == raw
+    assert sbp == "110"
+    assert dbp == "97"
+    assert map_val == "57"
+
+
 @pytest.mark.skipif(vital_reader.cv2 is None, reason="OpenCV not available")
 def test_read_bp_roi_uses_sanitized_text(monkeypatch):
     np = pytest.importorskip("numpy")
     responses = iter([
-        ("11.0/97(57)", 0.9),
+        ("11097(57", 0.9),
         ("", 0.0),
     ])
 
@@ -41,7 +59,7 @@ def test_read_bp_roi_uses_sanitized_text(monkeypatch):
     roi = np.zeros((10, 10, 3), dtype=np.uint8)
     text, sbp, dbp, map_val = vital_reader.read_bp_roi(roi)
 
-    assert text == "110/97(57)"
+    assert text == "11097(57)"
     assert sbp == "110"
     assert dbp == "97"
     assert map_val == "57"

--- a/vital_reader.py
+++ b/vital_reader.py
@@ -420,6 +420,17 @@ ALLOW_MODE_ASC = (
 )
 
 PAT_BP = re.compile(r'(\d{2,3})/(\d{2,3})\(?([0-9]{2,3})\)?')
+PAT_BP_TOKEN = re.compile(r'\d+(?:\.\d+)?')
+PREFERRED_BP_SPLITS = [
+    (3, 2, 2),
+    (3, 3, 2),
+    (3, 2, 3),
+    (2, 3, 2),
+    (2, 2, 3),
+    (3, 3, 3),
+    (2, 3, 3),
+    (2, 2, 2),
+]
 
 
 VENT_MODE_CANONICAL = {
@@ -471,16 +482,52 @@ def parse_bp_text(raw: str):
     match = PAT_BP.search(normalized)
     if match:
         return normalized, match.group(1), match.group(2), match.group(3)
-    fallback = re.search(r'(\d{4,6})\(?([0-9]{2,3})\)?', normalized)
-    if fallback:
-        digits = fallback.group(1)
-        if len(digits) <= 4:
-            sbp, dbp = digits[:2], digits[2:]
-        elif len(digits) == 5:
-            sbp, dbp = digits[:3], digits[3:]
-        else:
-            sbp, dbp = digits[:3], digits[3:]
-        return normalized, sbp, dbp, fallback.group(2)
+
+    matches = list(PAT_BP_TOKEN.finditer(raw))
+    tokens = []
+    for idx, m in enumerate(matches):
+        token = m.group()
+        if '.' in token:
+            if token.endswith('.0'):
+                base = token[:-2]
+                after = raw[m.end():]
+                keep_zero = after.startswith('/')
+                if idx == 0 and len(base) <= 2:
+                    keep_zero = True
+                token = f"{base}0" if keep_zero else base
+            else:
+                token = token.replace('.', '')
+        tokens.append(token)
+
+    tokens = [tok for tok in tokens if tok]
+    if len(tokens) >= 3:
+        return normalized, tokens[0], tokens[1], tokens[2]
+
+    digits_only = ''.join(ch for ch in normalized if ch.isdigit())
+    if not digits_only:
+        digits_only = ''.join(ch for ch in raw if ch.isdigit())
+
+    if len(tokens) == 2 and tokens[0] and tokens[1]:
+        first, last = tokens
+        for sbp_len in (3, 2):
+            for dbp_len in (2, 3):
+                if sbp_len + dbp_len != len(first):
+                    continue
+                sbp = first[:sbp_len]
+                dbp = first[sbp_len:]
+                if sbp and dbp:
+                    return normalized, sbp, dbp, last
+
+    for lengths in PREFERRED_BP_SPLITS:
+        l1, l2, l3 = lengths
+        if l1 + l2 + l3 != len(digits_only):
+            continue
+        sbp = digits_only[:l1]
+        dbp = digits_only[l1:l1 + l2]
+        map_val = digits_only[l1 + l2:l1 + l2 + l3]
+        if sbp and dbp and map_val:
+            return normalized, sbp, dbp, map_val
+
     return normalized, "", "", ""
 
 


### PR DESCRIPTION
## Summary
- refine blood pressure parsing fallback to harvest digit tokens and explore common digit splits when separators are lost
- add regression tests covering decimal tokens and missing slash OCR outputs
- update the read_bp_roi test stub to exercise the fallback logic

## Testing
- pytest tests/test_vital_reader_bp.py

------
https://chatgpt.com/codex/tasks/task_e_68ca5dfff330832b960dd881b8b6cf7a