### PR TITLE
Switch VTset logging to PS when vent mode is pressure support

### DIFF
--- a/tests/test_vital_reader_vent_mode.py
+++ b/tests/test_vital_reader_vent_mode.py
@@ -3,7 +3,11 @@ import sys
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
-from vital_reader import normalize_vent_mode_label
+from vital_reader import (
+    apply_pressure_support_split,
+    is_pressure_support_mode,
+    normalize_vent_mode_label,
+)
 
 
 def test_normalize_vent_mode_translates_katakana_label():
@@ -20,3 +24,21 @@ def test_normalize_vent_mode_handles_full_width_space():
 
 def test_normalize_vent_mode_handles_mixed_ascii_and_katakana():
     assert normalize_vent_mode_label("AUTOモード") == "AUTO MODE"
+
+
+def test_is_pressure_support_mode_detects_psv_token():
+    assert is_pressure_support_mode("SIMV/PSV")
+
+
+def test_apply_pressure_support_split_assigns_ps_when_mode_matches():
+    results = {"VentMode": "SPONT", "VTset": "12"}
+    apply_pressure_support_split(results)
+    assert results["PS"] == "12"
+    assert results["VTset"] == ""
+
+
+def test_apply_pressure_support_split_keeps_vtset_when_not_ps_mode():
+    results = {"VentMode": "SIMV", "VTset": "350"}
+    apply_pressure_support_split(results)
+    assert results["PS"] == ""
+    assert results["VTset"] == "350"

--- a/vital_reader.py
+++ b/vital_reader.py
@@ -445,6 +445,13 @@ VENT_MODE_TRANSLATIONS = [
     ("モード", "MODE"),
 ]
 
+PRESSURE_SUPPORT_MODE_TOKENS = {
+    "PS",
+    "PSV",
+    "SPONT",
+    "SPONTANEOUS",
+}
+
 
 def normalize_vent_mode_label(raw: str) -> str:
     """Normalize raw OCR output for the ventilator mode label."""
@@ -472,6 +479,33 @@ def normalize_vent_mode_label(raw: str) -> str:
 
     ascii_text = re.sub(r"\s+", " ", text).strip().upper()
     return VENT_MODE_CANONICAL.get(ascii_text, ascii_text)
+
+
+def is_pressure_support_mode(mode: str) -> bool:
+    """Return ``True`` if ``mode`` represents a pressure support style mode."""
+
+    if not mode:
+        return False
+
+    tokens = [t for t in re.split(r"[^A-Z0-9]+", mode.upper()) if t]
+    return any(token in PRESSURE_SUPPORT_MODE_TOKENS for token in tokens)
+
+
+def apply_pressure_support_split(results: dict) -> None:
+    """Populate ``PS`` or ``VTset`` based on the ventilator mode in ``results``."""
+
+    if "VTset" not in results and "PS" not in results:
+        return
+
+    vt_value = results.get("VTset", "") or ""
+    mode = results.get("VentMode", "") or ""
+
+    if is_pressure_support_mode(mode):
+        results["PS"] = vt_value
+        results["VTset"] = ""
+    else:
+        results["PS"] = ""
+        results["VTset"] = vt_value
 
 
 def parse_bp_text(raw: str):
@@ -710,6 +744,8 @@ def ocr_vitals_from_image(image_path):
     cvp_crop = crop_image(img, CVP_COORDS)
     results['CVP'] = read_cvp_roi(cvp_crop)
 
+    apply_pressure_support_split(results)
+
     if detect_spontaneous_breath(img, SPONT_BREATH_COORDS):
         print("自発呼吸検出")
         results['SpontaneousBreath'] = 'detected'
@@ -721,7 +757,7 @@ def ocr_vitals_from_image(image_path):
 ALL_COLUMNS = [
     "SBP", "DBP", "MAP", "HR", "SpO2", "BSR1", "BSR2", "Tskin", "Trect", "etCO2",
     "RR", "Ppeak", "Pmean", "PEEPact", "RRact", "I_E", "FiO2", "VTe", "VTi",
-    "PEEPset", "VTset", "VentMode", "CVP", "pH", "PaCO2", "pO2", "Hct", "K", "Na", "Cl",
+    "PEEPset", "VTset", "PS", "VentMode", "CVP", "pH", "PaCO2", "pO2", "Hct", "K", "Na", "Cl",
     "Ca", "Glu", "Lac", "tBil", "HCO3", "BE", "Alb"
 ]
 


### PR DESCRIPTION
## Summary
- detect pressure-support ventilator modes and shift the VTset reading into a PS field while clearing VTset
- expose the helper so OCR results and CSV exports include the new PS column, leaving VTset for non-PS modes
- extend the vital reader tests to cover the new mapping and pressure support detection

## Testing
- pytest tests/test_vital_reader_vent_mode.py


------
https://chatgpt.com/codex/tasks/task_e_68ca60c94378832bbdcc52c0d2c91afc