### PR TITLE
Improve BP parsing for misread DBP values

### DIFF
--- a/tests/test_vital_reader_bp.py
+++ b/tests/test_vital_reader_bp.py
@@ -36,6 +36,26 @@ def test_parse_bp_text_handles_missing_slash():
     assert dbp == "97"
     assert map_val == "57"
 
+
+def test_parse_bp_text_recovers_dbp_with_spurious_digit():
+    raw = "106166(84)"
+    text, sbp, dbp, map_val = vital_reader.parse_bp_text(raw)
+
+    assert text == "106/66(84)"
+    assert sbp == "106"
+    assert dbp == "66"
+    assert map_val == "84"
+
+
+def test_parse_bp_text_recovers_dbp_without_map():
+    raw = "106166"
+    text, sbp, dbp, map_val = vital_reader.parse_bp_text(raw)
+
+    assert text == "106/66"
+    assert sbp == "106"
+    assert dbp == "66"
+    assert map_val == ""
+
 @pytest.mark.skipif(vital_reader.cv2 is None, reason="OpenCV not available")
 def test_read_bp_roi_uses_sanitized_text(monkeypatch):
     np = pytest.importorskip("numpy")

--- a/vital_reader.py
+++ b/vital_reader.py
@@ -239,6 +239,58 @@ def _split_bp_digits(digits: str) -> tuple[str, str]:
     return best
 
 
+def _refine_bp_values(sbp: str, dbp: str, map_val: str) -> tuple[str, str]:
+    """Correct implausible blood pressure splits when possible."""
+
+    if not sbp or not dbp:
+        return sbp, dbp
+
+    try:
+        sbp_int = int(sbp)
+        dbp_int = int(dbp)
+    except ValueError:
+        return sbp, dbp
+
+    if sbp_int >= dbp_int:
+        return sbp, dbp
+
+    map_int: Optional[int] = None
+    if map_val:
+        try:
+            map_int = int(map_val)
+        except ValueError:
+            map_int = None
+
+    def score(value: int) -> float:
+        if map_int is not None:
+            approx_map = round((sbp_int + 2 * value) / 3)
+            return abs(approx_map - map_int)
+        return abs(sbp_int - value)
+
+    best_val: Optional[int] = None
+    best_score = score(dbp_int)
+
+    for start in range(1, len(dbp)):
+        candidate_text = dbp[start:].lstrip("0")
+        if not candidate_text:
+            continue
+        try:
+            candidate_val = int(candidate_text)
+        except ValueError:
+            continue
+        if candidate_val < 20 or candidate_val > sbp_int:
+            continue
+        candidate_score = score(candidate_val)
+        if candidate_score < best_score:
+            best_score = candidate_score
+            best_val = candidate_val
+
+    if best_val is not None:
+        return str(sbp_int), str(best_val)
+
+    return sbp, dbp
+
+
 def parse_bp_text(raw_text: str) -> tuple[str, str, str, str]:
     """Parse blood pressure text into components.
 
@@ -275,6 +327,8 @@ def parse_bp_text(raw_text: str) -> tuple[str, str, str, str]:
 
     sbp = sbp.lstrip("0") or sbp
     dbp = dbp.lstrip("0") or dbp
+
+    sbp, dbp = _refine_bp_values(sbp, dbp, map_val)
 
     sanitized = ""
     if sbp and dbp:


### PR DESCRIPTION
## Summary
- refine blood pressure parsing so DBP readings that exceed SBP are corrected using MAP hints when available
- add regression tests that cover OCR outputs where the slash is misread as an extra digit

## Testing
- pytest tests/test_vital_reader_bp.py

------
https://chatgpt.com/codex/tasks/task_e_68cb839e8218832ba4776da33fe4f112