### PR TITLE
Add adrenaline thresholds and rule

### DIFF
--- a/main_surgery.py
+++ b/main_surgery.py
@@ -327,6 +327,8 @@ def prompt_thresholds():
         "SBP_u": get_val("SBP 上限 (SBP_u)", 90),
         "CVP_u": get_val("CVP 上限 (CVP_u)", 5),
         "CVP_c": get_val("Critical CVP 上限 (CVP_c)", 8),
+        "Ad_l": get_val("アドレナリン下限 (Ad_l)", 0.0),
+        "Ad_u": get_val("アドレナリン上限 (Ad_u)", 0.1),
     }
 
 
@@ -386,6 +388,60 @@ def update_furosemide_flags(vitals, vitals_memory):
         vitals_memory["FRO_LAST_DOSE_ENTRY"] = entry_key
         vitals_memory["FRO_DOSE_LOGGED"] = True
 
+
+def _normalize_optional_float(value):
+    """Return ``value`` as a float when possible, otherwise ``None``."""
+
+    if value is None:
+        return None
+    if isinstance(value, str):
+        s = value.strip()
+        if not s:
+            return None
+        try:
+            value = float(s)
+        except ValueError:
+            return None
+    elif isinstance(value, (int, float)):
+        value = float(value)
+    else:
+        return None
+
+    if math.isnan(value):
+        return None
+    return value
+
+
+def merge_latest_adrenaline(vitals, vitals_memory, aliases=("adrenaline", "Adrenaline", "ADR")):
+    """Inject the most recent adrenaline value into ``vitals``.
+
+    The vitals CSV interleaves general vital signs and drug infusions.  When a
+    new vitals row is recorded without an updated adrenaline column the latest
+    dose should still be available for rule evaluation.  This helper keeps the
+    most recent non-empty value in ``vitals_memory`` and reuses it when
+    necessary.  It also normalises known alias keys (e.g. ``"Adrenaline"``)
+    so that downstream logic can consistently rely on ``"adrenaline"``.
+    """
+
+    latest = vitals_memory.setdefault("LATEST_DRUG_VALUES", {})
+    value = None
+    for key in aliases:
+        value = _normalize_optional_float(vitals.get(key))
+        if value is not None:
+            break
+
+    if value is None:
+        stored = latest.get("adrenaline")
+        if stored is not None:
+            vitals["adrenaline"] = stored
+        return
+
+    latest["adrenaline"] = value
+    vitals["adrenaline"] = value
+    for key in aliases:
+        if key in vitals:
+            vitals[key] = value
+
 # ---------------- ベッド選択＆CSVパス解決 ----------------
 
 def select_bed_and_csv(vitals_base_dir: Path) -> Path:
@@ -444,6 +500,7 @@ def main_loop(
         "FRO_CVP_BASE": None,
         "FRO_DOSE_LOGGED": False,
         "FRO_LAST_DOSE_ENTRY": None,
+        "LATEST_DRUG_VALUES": {},
     }
     print("\n==== 自動判定を開始（Ctrl+Cで終了）====")
     while True:
@@ -452,6 +509,7 @@ def main_loop(
             print("[!] バイタル情報が不完全、再試行します")
             time.sleep(10); continue
 
+        merge_latest_adrenaline(vitals, vitals_memory)
         print("【判定直前しきい値】", thresholds)
         print("【判定直前バイタル】", vitals)
 
@@ -460,8 +518,10 @@ def main_loop(
         update_furosemide_flags(vitals, vitals_memory)
 
         # 状態注入
-        for key in vitals_memory:
-            vitals[key] = vitals_memory[key]
+        for key, value in vitals_memory.items():
+            if key == "LATEST_DRUG_VALUES":
+                continue
+            vitals[key] = value
 
         # 新しいデータ行でのみ評価
         if last_timestamp is None or vitals['timestamp'] != last_timestamp:

--- a/tests/test_evaluate_all.py
+++ b/tests/test_evaluate_all.py
@@ -1,3 +1,5 @@
+import pytest
+
 import main_surgery as ms
 
 
@@ -209,3 +211,33 @@ def test_evaluate_all_bpdown_only_when_sbp_low(monkeypatch):
         "next_id": None,
         "comment": "",
     }]
+
+
+def test_merge_latest_adrenaline_reuses_previous_value():
+    vitals_memory = {"LATEST_DRUG_VALUES": {}}
+
+    vitals = {"Adrenaline": "0.2"}
+    ms.merge_latest_adrenaline(vitals, vitals_memory)
+    assert vitals["adrenaline"] == 0.2
+    assert vitals_memory["LATEST_DRUG_VALUES"]["adrenaline"] == 0.2
+
+    next_vitals = {}
+    ms.merge_latest_adrenaline(next_vitals, vitals_memory)
+    assert next_vitals["adrenaline"] == 0.2
+
+
+def test_tree_adrenaline_reduction_rule_triggers():
+    pytest.importorskip("yaml")
+    thresholds = {"CVP_u": 5, "SBP_u": 90, "Ad_u": 0.1}
+    tree_df = ms.load_tree("tree.yaml")
+
+    vitals = {"CVP": 4.0, "SBP": 100.0, "adrenaline": 0.2}
+    results = ms.evaluate_adrenaline(vitals, tree_df, thresholds)
+    ids = {r["id"] for r in results}
+    assert "AD_REDUCE_WHEN_HIGH_BP" in ids
+    message = [r["instruction"] for r in results if r["id"] == "AD_REDUCE_WHEN_HIGH_BP"]
+    assert message == ["アドレナリンを減量してもよいです。"]
+
+    vitals["adrenaline"] = 0.05
+    results = ms.evaluate_adrenaline(vitals, tree_df, thresholds)
+    assert "AD_REDUCE_WHEN_HIGH_BP" not in {r["id"] for r in results}

--- a/threshold_panel.py
+++ b/threshold_panel.py
@@ -20,6 +20,8 @@ DEFAULT_THRESHOLDS: Dict[str, float] = {
     "SBP_u": 90.0,
     "CVP_u": 5.0,
     "CVP_c": 8.0,
+    "Ad_l": 0.0,
+    "Ad_u": 0.1,
 }
 
 

--- a/tree.yaml
+++ b/tree.yaml
@@ -350,6 +350,15 @@ rules:
   - CVP
   actions:
   - NEXT:なし
+- id: AD_REDUCE_WHEN_HIGH_BP
+  when: vitals.get("CVP") < {{CVP_u}} and vitals.get("SBP") > {{SBP_u}} and vitals.get("adrenaline") > {{Ad_u}}
+  message: アドレナリンを減量してもよいです。
+  severity: info
+  tags:
+  - a,r
+  - AD
+  - SBP
+  - CVP
 - id: AD_U_02
   when: value == 0.2
   message: これ以上アドレナリンは上げられません。開胸またはECMOの準備をしてください。


### PR DESCRIPTION
## Summary
- add Ad_l/Ad_u thresholds to defaults and prompt so the threshold editor exposes adrenaline limits
- merge the latest adrenaline infusion into vitals and add a tree.yaml rule that suggests reducing the dose when SBP and CVP thresholds are satisfied
- extend the evaluate_all tests to cover adrenaline persistence and the new reduction instruction

## Testing
- pytest *(fails: pandas is unavailable in the environment and vital_reader.py has a pre-existing SyntaxError)*

------
https://chatgpt.com/codex/tasks/task_e_68cce2edab14832b9f1ba7f2d68f9d9e