### PR TITLE
Update SBP trend alerts with targeted interventions

### DIFF
--- a/tests/test_sbp_trend.py
+++ b/tests/test_sbp_trend.py
@@ -1,13 +1,21 @@
 import csv
 import os
+import sys
 import tempfile
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 from vitals.sbp_trend import check_sbp_trend
 
 
 def create_csv(rows):
     tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".csv", mode="w", newline="")
-    writer = csv.DictWriter(tmp, fieldnames=["timestamp", "SBP"])
+    fieldnames = ["timestamp", "SBP"]
+    for row in rows:
+        for key in row.keys():
+            if key not in fieldnames:
+                fieldnames.append(key)
+    writer = csv.DictWriter(tmp, fieldnames=fieldnames)
     writer.writeheader()
     for r in rows:
         writer.writerow(r)
@@ -15,29 +23,58 @@ def create_csv(rows):
     return tmp.name
 
 
-def test_sbp_increase_triggers_vasodilator_instruction():
+ALERT_MESSAGE = "急激な血圧の増減を確認！直前に行った介入を確認し、バイタルを注意深く観察する"
+
+
+def test_sbp_increase_high_vasopressin_suggests_pitressin_reduction():
     path = create_csv([
-        {"timestamp": "2024-01-01 00:00:00", "SBP": 80},
-        {"timestamp": "2024-01-01 00:10:00", "SBP": 95},
+        {"timestamp": "2024-01-01 00:00:00", "SBP": 80, "vasopressin": 0.02, "hanp": 0.25},
+        {"timestamp": "2024-01-01 00:10:00", "SBP": 95, "vasopressin": 0.04, "hanp": 0.25},
     ])
     try:
         result = check_sbp_trend(path)
         assert result and result["alarm"]
         assert result["change"] == 15
-        assert "血管拡張薬" in result["instruction"]
+        instruction = result["instruction"]
+        assert ALERT_MESSAGE in instruction
+        assert "上昇" in instruction
+        assert "ピトレシンを減量" in instruction
+        assert "ハンプの増量" not in instruction
     finally:
         os.unlink(path)
 
 
-def test_sbp_decrease_triggers_vasopressor_instruction():
+def test_sbp_increase_low_hanp_suggests_hanp_increase():
     path = create_csv([
-        {"timestamp": "2024-01-01 00:00:00", "SBP": 100},
-        {"timestamp": "2024-01-01 00:10:00", "SBP": 85},
+        {"timestamp": "2024-01-01 00:00:00", "SBP": 85, "vasopressin": 0.02, "hanp": 0.18},
+        {"timestamp": "2024-01-01 00:10:00", "SBP": 100, "vasopressin": 0.02, "hanp": 0.18},
+    ])
+    try:
+        result = check_sbp_trend(path)
+        assert result and result["alarm"]
+        assert result["change"] == 15
+        instruction = result["instruction"]
+        assert ALERT_MESSAGE in instruction
+        assert "上昇" in instruction
+        assert "ハンプの増量を検討" in instruction
+    finally:
+        os.unlink(path)
+
+
+def test_sbp_decrease_prompts_bleeding_panel_and_drug_adjustments():
+    path = create_csv([
+        {"timestamp": "2024-01-01 00:00:00", "SBP": 110, "vasopressin": 0.12, "hanp": 0.07},
+        {"timestamp": "2024-01-01 00:10:00", "SBP": 95, "vasopressin": 0.08, "hanp": 0.03},
     ])
     try:
         result = check_sbp_trend(path)
         assert result and result["alarm"]
         assert result["change"] == -15
-        assert "昇圧剤" in result["instruction"]
+        instruction = result["instruction"]
+        assert ALERT_MESSAGE in instruction
+        assert "低下" in instruction
+        assert "出血パネル" in instruction
+        assert "ピトレシンの増量を検討" in instruction
+        assert "ハンプを0.05" in instruction
     finally:
         os.unlink(path)

--- a/vitals/sbp_trend.py
+++ b/vitals/sbp_trend.py
@@ -6,6 +6,32 @@ from pathlib import Path
 from typing import Any, Dict, Optional, Union
 
 
+BASE_INSTRUCTION = "急激な血圧の増減を確認！直前に行った介入を確認し、バイタルを注意深く観察する"
+
+
+def _parse_float(*values: Any) -> Optional[float]:
+    for value in values:
+        if value is None:
+            continue
+        if isinstance(value, (int, float)):
+            return float(value)
+        text = str(value).strip()
+        if not text:
+            continue
+        try:
+            return float(text)
+        except ValueError:
+            continue
+    return None
+
+
+def _format_change(value: float) -> str:
+    text = f"{value:.1f}"
+    if text.endswith(".0"):
+        return text[:-2]
+    return text
+
+
 def check_sbp_trend(
     csv_path: Union[Path, str],
     threshold: float = 10.0,
@@ -43,7 +69,14 @@ def check_sbp_trend(
             sbp = float(r.get("SBP", ""))
         except Exception:
             continue
-        records.append({"timestamp": ts, "SBP": sbp})
+        vasopressin = _parse_float(r.get("vasopressin"), r.get("pitressin"))
+        hanp = _parse_float(r.get("hanp"))
+        records.append({
+            "timestamp": ts,
+            "SBP": sbp,
+            "vasopressin": vasopressin,
+            "hanp": hanp,
+        })
     if not records:
         return None
 
@@ -55,16 +88,39 @@ def check_sbp_trend(
     past = past_candidates[-1]
 
     diff = latest["SBP"] - past["SBP"]
+    vasopressin = latest.get("vasopressin")
+    hanp = latest.get("hanp")
     if diff >= threshold:
-        return {
-            "alarm": True,
-            "change": diff,
-            "instruction": "血圧上昇: 血管拡張薬を増量してください",
-        }
+        change_text = _format_change(diff)
+        instruction_lines = [
+            BASE_INSTRUCTION,
+            f"SBPが10分で{change_text} mmHg上昇しています。",
+        ]
+        if vasopressin is not None and vasopressin > 0.03:
+            instruction_lines.append(
+                f"vasopressinが0.03U/kg/hを超えています（現在: {vasopressin:.3f}）。ピトレシンを減量することを検討してください。"
+            )
+        if hanp is not None and hanp < 0.2:
+            instruction_lines.append(
+                f"HANPが0.2μg/kg/min未満です（現在: {hanp:.3f}）。ハンプの増量を検討してください。"
+            )
+        instruction = "\n".join(instruction_lines)
+        return {"alarm": True, "change": diff, "instruction": instruction}
     if diff <= -threshold:
-        return {
-            "alarm": True,
-            "change": diff,
-            "instruction": "血圧低下: 昇圧剤を増量してください",
-        }
+        change_text = _format_change(abs(diff))
+        instruction_lines = [
+            BASE_INSTRUCTION,
+            f"SBPが10分で{change_text} mmHg低下しています。",
+            "出血パネルを入力してください。",
+        ]
+        if vasopressin is not None and vasopressin < 0.1:
+            instruction_lines.append(
+                f"vasopressinが0.1U/kg/h未満です（現在: {vasopressin:.3f}）。ピトレシンの増量を検討してください。"
+            )
+        if hanp is not None and hanp < 0.05:
+            instruction_lines.append(
+                f"HANPが0.05μg/kg/min未満です（現在: {hanp:.3f}）。ハンプを0.05μg/kg/minまで増量することを検討してください。"
+            )
+        instruction = "\n".join(instruction_lines)
+        return {"alarm": True, "change": diff, "instruction": instruction}
     return None


### PR DESCRIPTION
## Summary
- unify the SBP trend alert messaging while adding conditional instructions for drug adjustments and bleeding panel entry
- parse vasopressin and HANP values from vital history rows to drive the new recommendations
- expand the SBP trend unit tests to cover the new intervention guidance and flexible CSV columns

## Testing
- pytest tests/test_sbp_trend.py

------
https://chatgpt.com/codex/tasks/task_e_68cce78b9850832bb8b93baac1f95754