### PR TITLE
Add vasopressin reduction cooldown for BPUP instruction

### DIFF
--- a/main_surgery.py
+++ b/main_surgery.py
@@ -119,6 +119,8 @@ def resolve_path(
 VITALS_BASE_DIR = resolve_path("VITALS_BASE_DIR", "VITALS_BASE_DIR", DEFAULT_VITALS_BASE_CANDIDATES, must_exist=False)
 
 DEFAULT_PAUSE_MIN = 10  # 予備のデフォルト（Treeに数値が無い等のとき）
+BPUP_PITRESSIN_PAUSE_KEY = "BPUP_PITRESSIN_DROP_PAUSE_UNTIL"
+BPUP_PITRESSIN_PAUSE_SECONDS = 60 * 60
 
 # ---------------- ユーティリティ ----------------
 
@@ -216,7 +218,14 @@ def adjust_spo2_actions(instructions, surgery_type: str):
 
 # ---------------- 共通評価 ----------------
 
-def evaluate_all(vitals: dict, tree_df, thresholds, phase='a', bpup_tree_df=None):
+def evaluate_all(
+    vitals: dict,
+    tree_df,
+    thresholds,
+    phase='a',
+    bpup_tree_df=None,
+    previous_vitals=None,
+):
     """Evaluate all vitals and return intervention instructions.
     """
     instructions = []
@@ -250,7 +259,12 @@ def evaluate_all(vitals: dict, tree_df, thresholds, phase='a', bpup_tree_df=None
             except Exception:
                 elapsed = None
             instructions += evaluate_bpup(
-                vitals, chosen_tree, thresholds, phase, elapsed_minutes=elapsed
+                vitals,
+                chosen_tree,
+                thresholds,
+                phase,
+                previous_vitals=previous_vitals,
+                elapsed_minutes=elapsed,
             )
         elif sbp_l is not None and sbp < sbp_l:
             instructions += evaluate_bpdown(vitals, tree_df, thresholds, phase)
@@ -268,7 +282,15 @@ def evaluate_all(vitals: dict, tree_df, thresholds, phase='a', bpup_tree_df=None
 
 # ---------------- CVP follow-up ----------------
 
-def compute_cvp_follow_instructions(base_results, vitals, tree_df, thresholds, surgery_type, bpup_tree_df=None):
+def compute_cvp_follow_instructions(
+    base_results,
+    vitals,
+    tree_df,
+    thresholds,
+    surgery_type,
+    bpup_tree_df=None,
+    previous_vitals=None,
+):
     """Return follow-up instructions after CVP check.
 
     Any instructions that were already present alongside ``CVP_UPPER_CHECK`` in
@@ -278,7 +300,12 @@ def compute_cvp_follow_instructions(base_results, vitals, tree_df, thresholds, s
     """
     other = [r for r in base_results if r.get("id") != "CVP_UPPER_CHECK"]
     follow_raw = other + evaluate_all(
-        vitals, tree_df, thresholds, phase="a", bpup_tree_df=bpup_tree_df
+        vitals,
+        tree_df,
+        thresholds,
+        phase="a",
+        bpup_tree_df=bpup_tree_df,
+        previous_vitals=previous_vitals,
     )
     return [
         r
@@ -412,6 +439,42 @@ def _normalize_optional_float(value):
     return value
 
 
+def _merge_latest_drug_value(vitals, vitals_memory, canonical_key, aliases=()):
+    """Normalise drug values and preserve the latest entry.
+
+    Parameters
+    ----------
+    vitals : dict
+        Latest vitals row to be mutated in-place.
+    vitals_memory : dict
+        Persistent state dictionary storing ``"LATEST_DRUG_VALUES"``.
+    canonical_key : str
+        Key name used internally by the rule engine.
+    aliases : tuple[str, ...]
+        Alternative column names that may appear in the CSV.
+    """
+
+    latest = vitals_memory.setdefault("LATEST_DRUG_VALUES", {})
+    keys = (canonical_key,) + tuple(aliases)
+
+    value = None
+    for key in keys:
+        value = _normalize_optional_float(vitals.get(key))
+        if value is not None:
+            break
+
+    if value is None:
+        stored = latest.get(canonical_key)
+        if stored is not None:
+            for key in keys:
+                vitals[key] = stored
+        return
+
+    latest[canonical_key] = value
+    for key in keys:
+        vitals[key] = value
+
+
 def merge_latest_adrenaline(vitals, vitals_memory, aliases=("adrenaline", "Adrenaline", "ADR")):
     """Inject the most recent adrenaline value into ``vitals``.
 
@@ -423,24 +486,7 @@ def merge_latest_adrenaline(vitals, vitals_memory, aliases=("adrenaline", "Adren
     so that downstream logic can consistently rely on ``"adrenaline"``.
     """
 
-    latest = vitals_memory.setdefault("LATEST_DRUG_VALUES", {})
-    value = None
-    for key in aliases:
-        value = _normalize_optional_float(vitals.get(key))
-        if value is not None:
-            break
-
-    if value is None:
-        stored = latest.get("adrenaline")
-        if stored is not None:
-            vitals["adrenaline"] = stored
-        return
-
-    latest["adrenaline"] = value
-    vitals["adrenaline"] = value
-    for key in aliases:
-        if key in vitals:
-            vitals[key] = value
+    _merge_latest_drug_value(vitals, vitals_memory, "adrenaline", aliases)
 
 # ---------------- ベッド選択＆CSVパス解決 ----------------
 
@@ -500,6 +546,7 @@ def main_loop(
         "FRO_CVP_BASE": None,
         "FRO_DOSE_LOGGED": False,
         "FRO_LAST_DOSE_ENTRY": None,
+        BPUP_PITRESSIN_PAUSE_KEY: None,
         "LATEST_DRUG_VALUES": {},
     }
     print("\n==== 自動判定を開始（Ctrl+Cで終了）====")
@@ -509,7 +556,28 @@ def main_loop(
             print("[!] バイタル情報が不完全、再試行します")
             time.sleep(10); continue
 
+        previous_drug_values = dict(vitals_memory.get("LATEST_DRUG_VALUES", {}))
+
+        current_pit = None
+        for key in ("pitressin", "vasopressin", "Vasopressin", "PITRESSIN"):
+            current_pit = _normalize_optional_float(vitals.get(key))
+            if current_pit is not None:
+                break
+        prev_pit = previous_drug_values.get("pitressin")
+
+        if prev_pit is not None and current_pit is not None:
+            if current_pit < prev_pit:
+                vitals_memory[BPUP_PITRESSIN_PAUSE_KEY] = time.time() + BPUP_PITRESSIN_PAUSE_SECONDS
+            elif current_pit > prev_pit:
+                vitals_memory[BPUP_PITRESSIN_PAUSE_KEY] = None
+
         merge_latest_adrenaline(vitals, vitals_memory)
+        _merge_latest_drug_value(
+            vitals,
+            vitals_memory,
+            "pitressin",
+            aliases=("vasopressin", "Vasopressin", "PITRESSIN"),
+        )
         print("【判定直前しきい値】", thresholds)
         print("【判定直前バイタル】", vitals)
 
@@ -534,7 +602,14 @@ def main_loop(
                 )
 
             # A相
-            a_results_raw = evaluate_all(vitals, tree_df, thresholds, phase='a', bpup_tree_df=bpup_tree_df)
+            a_results_raw = evaluate_all(
+                vitals,
+                tree_df,
+                thresholds,
+                phase='a',
+                bpup_tree_df=bpup_tree_df,
+                previous_vitals=previous_drug_values,
+            )
             a_results = adjust_spo2_actions(dedup_by_id(a_results_raw), surgery_type)
 
             ids = {r['id'] for r in a_results}
@@ -606,7 +681,13 @@ def main_loop(
                     # CHECK直後に、A相のうちCHECK以外を再評価して表示
                     if not skip_follow:
                         follow = compute_cvp_follow_instructions(
-                            a_results, vitals, tree_df, thresholds, surgery_type, bpup_tree_df
+                            a_results,
+                            vitals,
+                            tree_df,
+                            thresholds,
+                            surgery_type,
+                            bpup_tree_df,
+                            previous_vitals=previous_drug_values,
                         )
                         if not follow:
                             comment = handle_cvp_observation_comment(vitals_memory)
@@ -731,7 +812,16 @@ def main_loop(
                 vitals[key] = vitals_memory[key]
 
             r_results = adjust_spo2_actions(
-                dedup_by_id(evaluate_all(vitals, tree_df, thresholds, phase='r', bpup_tree_df=bpup_tree_df)),
+                dedup_by_id(
+                    evaluate_all(
+                        vitals,
+                        tree_df,
+                        thresholds,
+                        phase='r',
+                        bpup_tree_df=bpup_tree_df,
+                        previous_vitals=previous_drug_values,
+                    )
+                ),
                 surgery_type,
             )
             for inst in r_results:

--- a/tests/test_bpup_algorithm.py
+++ b/tests/test_bpup_algorithm.py
@@ -1,4 +1,5 @@
 import sys
+import time
 import types
 
 # Minimal pandas stub
@@ -6,6 +7,7 @@ pd_stub = types.SimpleNamespace(isna=lambda x: x != x)
 sys.modules.setdefault("pandas", pd_stub)
 
 from vitals.bpup_logic import evaluate_bpup
+import main_surgery as ms
 
 class DummyDF:
     def __init__(self, rows):
@@ -73,3 +75,39 @@ def test_bpup_a_suppressed_within_one_hour():
     df = DummyDF([row])
     vitals = {'noradrenaline': 0.05}
     assert evaluate_bpup(vitals, df, {}, 'a', elapsed_minutes=30) == []
+
+
+def test_bpup_pause_retained_while_drop_timer_active():
+    df = DummyDF([row])
+    vitals = {
+        'noradrenaline': 0,
+        'pitressin': 0.04,
+        ms.BPUP_PITRESSIN_PAUSE_KEY: time.time() + 120,
+    }
+    inst = evaluate_bpup(
+        vitals,
+        df,
+        {},
+        'a',
+        {'pitressin': 0.04},
+        elapsed_minutes=61,
+    )[0]
+    assert inst['pause_min'] == 1
+
+
+def test_bpup_pause_expires_after_timer():
+    df = DummyDF([row])
+    vitals = {
+        'noradrenaline': 0,
+        'pitressin': 0.04,
+        ms.BPUP_PITRESSIN_PAUSE_KEY: time.time() - 120,
+    }
+    inst = evaluate_bpup(
+        vitals,
+        df,
+        {},
+        'a',
+        {'pitressin': 0.04},
+        elapsed_minutes=61,
+    )[0]
+    assert inst['pause_min'] == 0

--- a/tests/test_evaluate_all.py
+++ b/tests/test_evaluate_all.py
@@ -213,6 +213,35 @@ def test_evaluate_all_bpdown_only_when_sbp_low(monkeypatch):
     }]
 
 
+def test_evaluate_all_forwards_previous_vitals(monkeypatch):
+    captured = {}
+
+    def mock_bpup(*args, **kwargs):
+        captured["previous"] = kwargs.get("previous_vitals")
+        return []
+
+    monkeypatch.setattr(ms, "evaluate_bpup", mock_bpup)
+    for fname in [
+        "evaluate_spo2",
+        "evaluate_critical_spo2",
+        "evaluate_sbp",
+        "evaluate_cvp",
+        "evaluate_adrenaline",
+        "evaluate_dobutamine",
+        "evaluate_bpdown",
+        "evaluate_bleed",
+        "evaluate_transfusion",
+    ]:
+        monkeypatch.setattr(ms, fname, lambda *a, **k: [])
+
+    vitals = {"SBP": 120}
+    thresholds = {"SBP_u": 90, "SBP_l": 70}
+    previous = {"pitressin": 0.05}
+    ms.evaluate_all(vitals, None, thresholds, previous_vitals=previous)
+
+    assert captured["previous"] is previous
+
+
 def test_merge_latest_adrenaline_reuses_previous_value():
     vitals_memory = {"LATEST_DRUG_VALUES": {}}
 

--- a/vitals/bpup_logic.py
+++ b/vitals/bpup_logic.py
@@ -1,3 +1,5 @@
+import time
+
 from common.rule_engine import evaluate_rules
 
 # BPUP（SBP上昇時）に関連する複数薬剤介入（CONT, HANP, VASO）含む
@@ -46,6 +48,10 @@ def evaluate_bpup(
         pit = vitals.get("pitressin") or 0
         hanp = vitals.get("hanp") or 0
         cont = vitals.get("contomin") or 0
+        pause_until = vitals.get("BPUP_PITRESSIN_DROP_PAUSE_UNTIL")
+        pause_active = False
+        if isinstance(pause_until, (int, float)):
+            pause_active = time.time() < pause_until
 
         msg = inst.get("instruction", "")
         if na > 0:
@@ -53,7 +59,7 @@ def evaluate_bpup(
         elif pit >= 0.03:
             msg = "ピトレシンを減量してもよいです"
             prev_pit = prev.get("pitressin")
-            if prev_pit is None or pit >= prev_pit:
+            if not pause_active and (prev_pit is None or pit >= prev_pit):
                 inst["pause_min"] = 0
         elif 0 <= pit <= 0.02:
             if 0 <= hanp < 0.2:


### PR DESCRIPTION
## Summary
- track pitressin values and record a one-hour cooldown when the vasopressin input is reduced so BPUP_A does not immediately re-fire
- generalize the drug value merging helper and forward previous drug values through evaluate_all and CVP follow-up logic
- respect the cooldown flag inside evaluate_bpup and cover the behaviour with new unit tests

## Testing
- pytest -q *(fails: pre-existing NameError for ALL_COLUMNS/spont_breath_model in vital_reader.py)*

------
https://chatgpt.com/codex/tasks/task_e_68ccf969ff98832ba5058e1eca98ebd9