### PR TITLE
Avoid forward-filling furosemide bolus values

### DIFF
--- a/main_surgery.py
+++ b/main_surgery.py
@@ -13,6 +13,22 @@ from pathlib import Path
 import json
 from typing import List, Optional, Union, Dict, MutableMapping
 
+try:  # Optional import for shared configuration with vital_reader
+    from vital_reader import NON_PERSISTENT_COLUMNS as _VR_NON_PERSISTENT
+except Exception:  # pragma: no cover - fallback when vital_reader is unavailable or missing the constant
+    _VR_NON_PERSISTENT = None
+
+# Columns that should not be forward-filled when reading the vitals CSV.
+NON_PERSISTENT_VITAL_COLUMNS = {"furosemide_mg"}
+if _VR_NON_PERSISTENT:
+    if isinstance(_VR_NON_PERSISTENT, str):
+        NON_PERSISTENT_VITAL_COLUMNS.add(_VR_NON_PERSISTENT)
+    else:
+        try:
+            NON_PERSISTENT_VITAL_COLUMNS.update(_VR_NON_PERSISTENT)
+        except TypeError:
+            NON_PERSISTENT_VITAL_COLUMNS.add(str(_VR_NON_PERSISTENT))
+
 # ==== 各評価ロジック ====
 from vitals.spo2_logic import evaluate_spo2
 from vitals.critical_spo2_logic import evaluate_critical_spo2
@@ -301,10 +317,15 @@ def get_latest_vitals(path: Union[Path, str]):
         if df.empty:
             return None
         # Forward-fill missing values so that failed OCR or partial updates
-        # do not erase previously captured vitals.  Any remaining NaNs (for
-        # columns that have never been populated) are converted to ``None`` to
-        # avoid propagating ``nan`` values to downstream logic.
-        df = df.ffill()
+        # do not erase previously captured vitals.  Columns marked as
+        # ``NON_PERSISTENT_VITAL_COLUMNS`` (e.g. bolus-only drug entries)
+        # are excluded from this operation so that a blank cell on the most
+        # recent row remains blank instead of reusing the last bolus value.
+        fill_columns = [
+            col for col in df.columns if col not in NON_PERSISTENT_VITAL_COLUMNS
+        ]
+        if fill_columns:
+            df.loc[:, fill_columns] = df.loc[:, fill_columns].ffill()
         last_row = df.iloc[-1]
         return {k: (None if pd.isna(v) else v) for k, v in last_row.items()}
     except Exception as e:

--- a/tests/test_get_latest_vitals_forward_fill.py
+++ b/tests/test_get_latest_vitals_forward_fill.py
@@ -17,3 +17,27 @@ def test_get_latest_vitals_forward_fill(tmp_path):
     df.to_csv(path, index=False)
     latest = get_latest_vitals(path)
     assert latest["SBP"] == 120
+
+
+def test_get_latest_vitals_skips_non_persistent_columns(tmp_path):
+    df = pd.DataFrame(
+        [
+            {
+                "timestamp": "2025-08-23 15:50:00",
+                "SBP": 120,
+                "furosemide_mg": 3,
+            },
+            {
+                "timestamp": "2025-08-23 15:51:00",
+                "SBP": pd.NA,
+                "furosemide_mg": pd.NA,
+            },
+        ]
+    )
+    path = tmp_path / "vitals.csv"
+    df.to_csv(path, index=False)
+
+    latest = get_latest_vitals(path)
+
+    assert latest["SBP"] == 120
+    assert latest["furosemide_mg"] is None


### PR DESCRIPTION
## Summary
- exclude non-persistent columns such as the furosemide bolus dose from forward-filling when loading vitals
- share the non-persistent column list between `main_surgery` and `vital_reader` with a safe fallback so the drug entry stays blank until re-logged
- add a regression test that ensures `get_latest_vitals` leaves `furosemide_mg` empty when the most recent CSV row is blank

## Testing
- `PYTHONPATH=. pytest tests/test_get_latest_vitals_forward_fill.py -q` *(skipped: pandas not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ccf52da680832bb6611693682c17cc