### PR TITLE
Improve dependency error messages for auto capture

### DIFF
--- a/auto_capture.py
+++ b/auto_capture.py
@@ -1,5 +1,22 @@
-from mss import mss
-from PIL import Image
+# NOTE:
+#   The script is frequently executed on machines that may not have all
+#   dependencies pre-installed (e.g. when run manually via ``py
+#   auto_capture.py``).  Previously this resulted in a rather cryptic
+#   ``ModuleNotFoundError`` for ``mss``.  To improve the UX we eagerly
+#   validate the imports and provide actionable installation guidance.
+try:
+    from mss import mss
+except ImportError as exc:  # pragma: no cover - defensive branch
+    raise SystemExit(
+        "Missing optional dependency 'mss'. Install it with 'pip install mss'."
+    ) from exc
+
+try:
+    from PIL import Image
+except ImportError as exc:  # pragma: no cover - defensive branch
+    raise SystemExit(
+        "Missing optional dependency 'Pillow'. Install it with 'pip install pillow'."
+    ) from exc
 import time
 import os
 from datetime import datetime


### PR DESCRIPTION
## Summary
- add defensive import handling for mss and Pillow in auto_capture script
- provide actionable installation guidance when dependencies are missing

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df6c5465d0832ba3f65b0c2d059be0