### PR TITLE
Improve auto_capture dependency guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,20 @@
 
 This project contains scripts for evaluating patient vitals during surgery.
 
+## Installation
+
+Install the optional screen-capture dependencies before running `auto_capture.py`:
+
+```bash
+pip install mss pillow
+```
+
+On Windows you can use:
+
+```powershell
+py -m pip install mss pillow
+```
+
 ## Configuration
 
 Paths used by `main_surgery.py` and `vital_reader.py` can be configured with environment variables, command line options, or a `config.json` file placed in the project root.

--- a/auto_capture.py
+++ b/auto_capture.py
@@ -8,14 +8,16 @@ try:
     from mss import mss
 except ImportError as exc:  # pragma: no cover - defensive branch
     raise SystemExit(
-        "Missing optional dependency 'mss'. Install it with 'pip install mss'."
+        "Missing optional dependency 'mss'. Install it with 'pip install mss' "
+        "(or 'py -m pip install mss' on Windows)."
     ) from exc
 
 try:
     from PIL import Image
 except ImportError as exc:  # pragma: no cover - defensive branch
     raise SystemExit(
-        "Missing optional dependency 'Pillow'. Install it with 'pip install pillow'."
+        "Missing optional dependency 'Pillow'. Install it with 'pip install pillow' "
+        "(or 'py -m pip install pillow' on Windows)."
     ) from exc
 import time
 import os


### PR DESCRIPTION
## Summary
- document the optional screen capture dependencies in the README with Windows-friendly commands
- expand the runtime dependency errors in `auto_capture.py` to mention the Windows `py -m pip` installation syntax

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df6d462f38832b85c766178194908e