### PR TITLE
Fix vitals CSV creation for dynamic columns

### DIFF
--- a/tests/test_save_vitals_new_file_extra_columns.py
+++ b/tests/test_save_vitals_new_file_extra_columns.py
@@ -1,0 +1,15 @@
+import csv
+from vital_reader import save_vitals_to_csv
+
+
+def test_save_vitals_creates_missing_columns(tmp_path):
+    csv_path = tmp_path / "vitals.csv"
+
+    save_vitals_to_csv({"SBP": 120, "SpontaneousBreath": "1"}, csv_path)
+
+    with open(csv_path, newline="", encoding="utf-8-sig") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    assert rows[-1]["SpontaneousBreath"] == "1"
+    assert rows[-1]["SBP"] == "120"

--- a/vital_reader.py
+++ b/vital_reader.py
@@ -961,7 +961,15 @@ def save_vitals_to_csv(vitals_dict, csv_path):
                 writer.writerow(row)
             os.replace(tmp_path, csv_path)
         else:
-            fieldnames = ["timestamp"] + ALL_COLUMNS
+            # ``row`` may contain dynamically discovered keys (for example
+            # SpontaneousBreath or drug doses).  When the CSV does not yet
+            # exist we must include those columns up front; otherwise
+            # ``DictWriter`` would raise ``ValueError: dict contains fields not
+            # in fieldnames`` and the vitals would be dropped silently.  The
+            # ``dict.fromkeys`` trick preserves order while removing duplicates.
+            fieldnames = list(
+                dict.fromkeys(["timestamp"] + ALL_COLUMNS + list(row.keys()))
+            )
             with open(tmp_path, "w", newline="", encoding="utf-8-sig") as f:
                 writer = csv.DictWriter(f, fieldnames=fieldnames)
                 writer.writeheader()


### PR DESCRIPTION
## Summary
- ensure `save_vitals_to_csv` keeps dynamically discovered columns when creating a new vitals CSV
- add regression coverage for saving spontaneous breathing data to a new file

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68df6f25a404832b86efe4782487a5d5