### PR TITLE
Handle UTF-8 BOM in vitals CSV reader

### DIFF
--- a/main_surgery.py
+++ b/main_surgery.py
@@ -351,7 +351,11 @@ def get_latest_vitals(path: Union[Path, str]):
         if path.suffix.lower() in (".xls", ".xlsx"):
             df = pd.read_excel(path)
         else:
-            df = pd.read_csv(path)
+            df = pd.read_csv(path, encoding="utf-8-sig")
+        # Remove a potential UTF-8 BOM from column names so that the expected
+        # ``timestamp`` column is accessible even when the CSV was produced by
+        # :func:`vital_reader.save_vitals_to_csv` (which writes ``utf-8-sig``).
+        df.columns = [str(col).lstrip("\ufeff") for col in df.columns]
         if df.empty:
             return None
         # Forward-fill missing values so that failed OCR or partial updates

--- a/tests/test_get_latest_vitals_forward_fill.py
+++ b/tests/test_get_latest_vitals_forward_fill.py
@@ -41,3 +41,19 @@ def test_get_latest_vitals_skips_non_persistent_columns(tmp_path):
 
     assert latest["SBP"] == 120
     assert latest["furosemide_mg"] is None
+
+
+def test_get_latest_vitals_handles_utf8_bom(tmp_path):
+    df = pd.DataFrame(
+        [
+            {"timestamp": "2025-08-23 15:50:00", "SBP": 120},
+            {"timestamp": "2025-08-23 15:55:00", "SBP": 125},
+        ]
+    )
+    path = tmp_path / "vitals.csv"
+    df.to_csv(path, index=False, encoding="utf-8-sig")
+
+    latest = get_latest_vitals(path)
+
+    assert latest["timestamp"] == "2025-08-23 15:55:00"
+    assert latest["SBP"] == 125


### PR DESCRIPTION
## Summary
- update `get_latest_vitals` to read CSV files with a UTF-8 BOM and normalise column names
- add a regression test confirming vitals CSVs saved with utf-8-sig remain readable

## Testing
- pytest tests/test_get_latest_vitals_forward_fill.py *(skipped: pandas not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68df76f083ac832ba64c877787a3dadb