### PR TITLE
Normalize vitals scalars returned by get_latest_vitals

### DIFF
--- a/main_surgery.py
+++ b/main_surgery.py
@@ -342,6 +342,17 @@ def compute_cvp_follow_instructions(
 
 # ---------------- データ取得 ----------------
 
+def _to_python_scalar(value):
+    """Return ``value`` converted to a built-in Python scalar when possible."""
+
+    if hasattr(value, "item"):
+        try:
+            return value.item()
+        except Exception:
+            pass
+    return value
+
+
 def get_latest_vitals(path: Union[Path, str]):
     if pd is None:
         print("[!] pandas が利用できないため CSV を読み込めません")
@@ -369,7 +380,10 @@ def get_latest_vitals(path: Union[Path, str]):
         if fill_columns:
             df.loc[:, fill_columns] = df.loc[:, fill_columns].ffill()
         last_row = df.iloc[-1]
-        return {k: (None if pd.isna(v) else v) for k, v in last_row.items()}
+        return {
+            k: (None if pd.isna(v) else _to_python_scalar(v))
+            for k, v in last_row.items()
+        }
     except Exception as e:
         print(f"[!] 読み込みエラー: {e}")
         return None

--- a/tests/test_get_latest_vitals_forward_fill.py
+++ b/tests/test_get_latest_vitals_forward_fill.py
@@ -57,3 +57,19 @@ def test_get_latest_vitals_handles_utf8_bom(tmp_path):
 
     assert latest["timestamp"] == "2025-08-23 15:55:00"
     assert latest["SBP"] == 125
+
+
+def test_get_latest_vitals_returns_python_scalars(tmp_path):
+    df = pd.DataFrame(
+        [
+            {"timestamp": "2025-08-23 15:55:00", "SBP": 125.0, "HR": 88},
+        ]
+    )
+    path = tmp_path / "vitals.csv"
+    df.to_csv(path, index=False)
+
+    latest = get_latest_vitals(path)
+
+    assert type(latest["SBP"]) is float
+    assert type(latest["HR"]) is int
+    assert "np.float" not in repr(latest)


### PR DESCRIPTION
## Summary
- convert values loaded from the vitals CSV into native Python scalars so printed dictionaries no longer show NumPy wrappers
- add a regression test to ensure the vitals loader returns Python ints/floats rather than NumPy scalar representations

## Testing
- `pytest tests/test_get_latest_vitals_forward_fill.py`


------
https://chatgpt.com/codex/tasks/task_e_68df7bb682c4832b9e72cf3b218ca2f4