### PR TITLE
Handle OCR decimal point variants in sanitize_numeric_text

### DIFF
--- a/tests/test_sanitize_numeric_text.py
+++ b/tests/test_sanitize_numeric_text.py
@@ -1,0 +1,25 @@
+import os
+import sys
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from vital_reader import sanitize_numeric_text
+
+
+@pytest.mark.parametrize(
+    "input_text, allow_dot, expected",
+    [
+        ("5・0", True, "5.0"),
+        ("5・0", False, "50"),
+        ("7･2", True, "7.2"),
+        ("8·3", True, "8.3"),
+        ("9点4", True, "9.4"),
+    ],
+)
+def test_sanitize_numeric_text_decimal_variants(input_text, allow_dot, expected):
+    assert sanitize_numeric_text(input_text, allow_dot=allow_dot) == expected
+
+
+def test_sanitize_numeric_text_signs_preserved():
+    assert sanitize_numeric_text("-1・5", allow_dot=True, allow_sign=True) == "-1.5"

--- a/vital_reader.py
+++ b/vital_reader.py
@@ -432,6 +432,19 @@ def sanitize_numeric_text(text: str, allow_dot: bool = False, allow_sign: bool =
     normalized = sanitize_ocr_text(text)
     if not normalized:
         return ""
+    if allow_dot:
+        # Some OCR outputs use middle dots or Japanese "点" characters to
+        # represent decimal points.  Converting these variants to the ASCII
+        # dot keeps decimal numbers intact while leaving integer-only
+        # sanitisation unaffected.
+        decimal_variants = {
+            "・",
+            "･",
+            "·",
+            "点",
+        }
+        for variant in decimal_variants:
+            normalized = normalized.replace(variant, ".")
     allowed = "0123456789"
     if allow_dot:
         allowed += "."


### PR DESCRIPTION
## Summary
- normalize alternate OCR decimal characters (middle dot, 点, etc.) to ASCII dots when decimals are allowed
- add unit coverage for sanitize_numeric_text including decimal variant handling and sign preservation

## Testing
- PYTHONPATH=. pytest tests/test_vital_reader_ie.py tests/test_sanitize_numeric_text.py

------
https://chatgpt.com/codex/tasks/task_e_68df7fe65264832b8677ab77432632b9