### PR TITLE
Handle middle dots in IE ratio normalization

### DIFF
--- a/tests/test_vital_reader_ie.py
+++ b/tests/test_vital_reader_ie.py
@@ -15,3 +15,7 @@ def test_normalize_ie_ratio_handles_full_width_characters():
 
 def test_normalize_ie_ratio_handles_alternate_separators_and_leading_zeros():
     assert normalize_ie_text("01/02.0") == "1:2"
+
+
+def test_normalize_ie_ratio_preserves_fractional_part_with_middle_dot():
+    assert normalize_ie_text("1：2・5") == "1:2.5"

--- a/vital_reader.py
+++ b/vital_reader.py
@@ -197,16 +197,29 @@ def sanitize_ocr_text(text: str) -> str:
     return re.sub(r"\s+", "", normalized)
 
 
+def _replace_chars(text: str, replacements: dict[str, str]) -> str:
+    for src, dest in replacements.items():
+        text = text.replace(src, dest)
+    return text
+
+
 def normalize_ie_text(text: str) -> str:
     normalized = sanitize_ocr_text(text)
     if not normalized:
         return ""
 
-    normalized = normalized.replace("\uFF1A", ":")
-    normalized = normalized.replace("/", ":")
-    normalized = normalized.replace("．", ".")
-    normalized = normalized.replace("。", ".")
-    normalized = normalized.replace(",", ".")
+    normalized = _replace_chars(normalized, {
+        "\uFF1A": ":",
+        "/": ":",
+    })
+    normalized = _replace_chars(normalized, {
+        "．": ".",
+        "。": ".",
+        ",": ".",
+        "・": ".",
+        "･": ".",
+        "·": ".",
+    })
     normalized = re.sub(r"[^0-9:.]", "", normalized)
     normalized = re.sub(r":+", ":", normalized)
 


### PR DESCRIPTION
## Summary
- add a helper to normalize IE text character variants and convert middle dots to ASCII dots
- ensure the IE ratio parser retains fractional parts when middle dot separators are used

## Testing
- PYTHONPATH=. pytest tests/test_vital_reader_ie.py

------
https://chatgpt.com/codex/tasks/task_e_68df84c44d98832b9543cdd0da899950