### PR TITLE
Enhance VTe OCR preprocessing

### DIFF
--- a/tests/test_vital_reader_vte.py
+++ b/tests/test_vital_reader_vte.py
@@ -1,0 +1,54 @@
+import os
+import sys
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import vital_reader
+
+
+np = pytest.importorskip("numpy")
+
+
+def _to_grayscale(image: np.ndarray) -> np.ndarray:
+    # Convert BGR to RGB ordering before applying standard luma weights.
+    rgb = image[..., ::-1]
+    weights = np.array([0.299, 0.587, 0.114], dtype=np.float32)
+    return np.tensordot(rgb, weights, axes=([-1], [0])).astype(np.float32)
+
+
+def test_read_vte_roi_enhances_blue_roi(monkeypatch):
+    base_color = np.array([200, 220, 255], dtype=np.uint8)
+    roi = np.full((32, 64, 3), base_color, dtype=np.uint8)
+
+    # Simulate darker digits painted on the light-blue background.
+    roi[:, 20:24, :] = np.array([160, 180, 220], dtype=np.uint8)
+    roi[8:24, 30:34, :] = np.array([30, 60, 120], dtype=np.uint8)
+
+    captured: dict[str, object] = {}
+
+    def fake_read_easy(image, allow_dot=False):
+        captured["image"] = image
+        captured["allow_dot"] = allow_dot
+        return "12.3", []
+
+    monkeypatch.setattr(vital_reader, "read_easy", fake_read_easy)
+
+    result = vital_reader.read_vte_roi(roi)
+
+    assert result == "12.3"
+    assert captured["allow_dot"] is True
+
+    processed = captured["image"]
+    assert isinstance(processed, np.ndarray)
+    assert processed.shape == roi.shape
+
+    original_gray = _to_grayscale(roi)
+    processed_gray = _to_grayscale(processed)
+
+    if vital_reader.cv2 is None:
+        assert processed is roi
+        assert np.allclose(processed_gray, original_gray)
+    else:
+        assert processed is not roi
+        assert processed_gray.max() - processed_gray.min() > original_gray.max() - original_gray.min()

--- a/vital_reader.py
+++ b/vital_reader.py
@@ -461,6 +461,42 @@ def read_num_roi(roi, allow_dot: bool = False, allow_sign: bool = False):
     return sanitize_numeric_text(text, allow_dot=allow_dot, allow_sign=allow_sign)
 
 
+def _enhance_blue_numeric_roi(roi):
+    """Apply contrast enhancement tailored for light-blue numeric readouts."""
+
+    if cv2 is None or np is None or not isinstance(roi, np.ndarray):
+        return roi
+
+    if roi.size == 0:
+        return roi
+
+    try:
+        if roi.dtype != np.uint8:
+            roi_uint8 = cv2.normalize(roi, None, 0, 255, cv2.NORM_MINMAX).astype(np.uint8)
+        else:
+            roi_uint8 = roi
+
+        hsv = cv2.cvtColor(roi_uint8, cv2.COLOR_BGR2HSV)
+        h, s, v = cv2.split(hsv)
+
+        clahe = cv2.createCLAHE(clipLimit=2.0, tileGridSize=(8, 8))
+        v_eq = clahe.apply(v)
+        v_norm = cv2.normalize(v_eq, None, 0, 255, cv2.NORM_MINMAX)
+        v_blur = cv2.GaussianBlur(v_norm, (3, 3), 0)
+
+        hsv_enhanced = cv2.merge((h, s, v_blur))
+        enhanced = cv2.cvtColor(hsv_enhanced, cv2.COLOR_HSV2BGR)
+        return enhanced
+    except Exception:
+        return roi
+
+
+def read_vte_roi(roi):
+    processed = _enhance_blue_numeric_roi(roi)
+    text, _ = read_easy(processed, allow_dot=True)
+    return sanitize_numeric_text(text, allow_dot=True)
+
+
 def read_temp_roi(roi):
     return read_num_roi(roi, allow_dot=True, allow_sign=True)
 
@@ -856,6 +892,7 @@ _ROI_READER_OVERRIDES = {
     "Tskin": read_temp_roi,
     "Trect": read_temp_roi,
     "I_E": read_ie_roi,
+    "VTe": read_vte_roi,
     "VentMode": read_mode_roi,
 }
 


### PR DESCRIPTION
## Summary
- add a blue-specific preprocessing helper for VTe that boosts contrast before running OCR
- register a dedicated VTe reader so only that ROI uses the enhanced pipeline while keeping numeric sanitisation intact
- add unit coverage that verifies the processed ROI passed to OCR and preserves decimal output

## Testing
- pytest tests/test_vital_reader_vte.py tests/test_sanitize_numeric_text.py

------
https://chatgpt.com/codex/tasks/task_e_68df89aac0c4832b8919f0364336fc23