### PR TITLE
Handle headless tkinter dialog fallback

### DIFF
--- a/main_surgery.py
+++ b/main_surgery.py
@@ -517,7 +517,18 @@ def yn_dialog(title, prompt):
         try:
             parent = tk.Tk()
             parent.withdraw()
+            parent.update_idletasks()
             created_root = True
+        except Exception:
+            return console_prompt()
+    else:
+        try:
+            # ``winfo_exists`` will raise if the widget is invalid, which can
+            # happen when ``tkinter`` failed to bind to a display.  Falling back
+            # to the console prompt prevents the automation loop from appearing
+            # to freeze when a dialog window cannot be rendered.
+            parent.winfo_exists()
+            parent.update_idletasks()
         except Exception:
             return console_prompt()
 


### PR DESCRIPTION
## Summary
- make tkinter confirmation dialogs fall back to console prompts when a display is unavailable
- ensure dialog parent widgets validate their state before showing Y/N prompts to avoid apparent freezes

## Testing
- python -m compileall main_surgery.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930e79fd258832b8c0d9759a95601e0)